### PR TITLE
Updated metadata for the SE_Z region.

### DIFF
--- a/input/metadata.csv
+++ b/input/metadata.csv
@@ -812,7 +812,7 @@ SE_U,SE,Sweden,U,Västmanland,59.64554,16.424561,270535,,,0
 SE_W,SE,Sweden,W,Dalarna,60.67861,15.60056,285724,,,0
 SE_X,SE,Sweden,X,Gävleborg,60.78056,16.65528,285452,,,0
 SE_Y,SE,Sweden,Y,Västernorrland,62.739633,16.929932,246082,,,0
-SE_Z,SE,Sweden,Z,Jämtland,63.35,14.4,129649,,,0
+SE_Z,SE,Sweden,Z,Jämtland Härjedalen,63.35,14.4,129649,,,0
 SG,SG,Singapore,,,1.352083,103.819836,5804337,,,-1
 SH,SH,Saint Helena,,,-24.143474,-10.030696,6059,,,-1
 SI,SI,Slovenia,,,46.151241,14.995463,2078654,,,-1


### PR DESCRIPTION
It has been called "Jämtland Härjedalen" in the covid19-eu-data dataset
since 2020-03-27.

(See also https://github.com/covid19-eu-zh/covid19-eu-data/pull/50 for a request to clean up historic datapoints).
