### PR TITLE
Refactor and simplify all the grouped_* methods

### DIFF
--- a/src/lib/pipeline.py
+++ b/src/lib/pipeline.py
@@ -256,7 +256,7 @@ class DataSource:
 
         # Filter out data according to the user-provided filter function
         if "query" in self.config:
-            data = data.query(self.config["query"])
+            data = data.query(self.config["query"]).copy()
 
         # Provide a stratified view of certain key variables
         if any(stratify_column in data.columns for stratify_column in ("age", "sex")):

--- a/src/pipelines/epidemiology/au_covid_19_au.py
+++ b/src/pipelines/epidemiology/au_covid_19_au.py
@@ -15,7 +15,6 @@
 from typing import Dict, List
 from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff
 
 
 class Covid19AuDataSource(DataSource):
@@ -33,15 +32,14 @@ class Covid19AuDataSource(DataSource):
                     "date": idx.date().isoformat(),
                     "country_code": "AU",
                     "subregion1_code": code,
-                    "confirmed": subset[0],
+                    "total_confirmed": subset[0],
                 }
                 if len(subset) > 1:
-                    record["deceased"] = subset[1]
+                    record["total_deceased"] = subset[1]
                 if len(subset) > 2:
-                    record["recovered"] = subset[2]
+                    record["total_recovered"] = subset[2]
                 if len(subset) > 3:
-                    record["tested"] = subset[3]
+                    record["total_tested"] = subset[3]
                 records.append(record)
 
-        data = DataFrame.from_records(records)
-        return grouped_diff(data, ["country_code", "subregion1_code", "date"])
+        return DataFrame.from_records(records)

--- a/src/pipelines/epidemiology/ca_authority.py
+++ b/src/pipelines/epidemiology/ca_authority.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat
-from lib.utils import grouped_diff
 
 
 class CanadaDataSource(DataSource):
@@ -31,9 +30,9 @@ class CanadaDataSource(DataSource):
                 columns={
                     "prname": "subregion1_name",
                     "numconf": "confirmed",
-                    "numdeaths": "deceased",
-                    "numtested": "tested",
-                    "numrecover": "recovered",
+                    "numdeaths": "total_deceased",
+                    "numtested": "total_tested",
+                    "numrecover": "total_recovered",
                 }
             )
             .drop(columns=["prnameFR"])
@@ -41,9 +40,6 @@ class CanadaDataSource(DataSource):
 
         # Convert date to ISO format
         data["date"] = data["date"].apply(lambda x: datetime_isoformat(x, "%d-%m-%Y"))
-
-        # Compute the daily counts
-        data = grouped_diff(data, ["subregion1_name", "date"])
 
         # Make sure all records have the country code
         data["country_code"] = "CA"

--- a/src/pipelines/epidemiology/config.yaml
+++ b/src/pipelines/epidemiology/config.yaml
@@ -399,7 +399,8 @@ sources:
       - url: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQgIjG5wYFaK-z25ciiNNSWUTdxMWKRe5_y1YLNMpCzJziFor16xyP3R1nKz1wAkN7F4w6gx4F6yUIp/pub?gid=1817954914&single=true&output=csv"
         opts:
           ext: csv
-  # Data sources for SE level 2
+
+  # Data sources for SE levels 1 + 2
   - name: pipelines.epidemiology.xx_covid19_eu_data.Covid19EuDataSource
     fetch:
       - url: "https://raw.github.com/covid19-eu-zh/covid19-eu-data/master/dataset/covid-19-se.csv"

--- a/src/pipelines/epidemiology/de_covid_19_germany_gae.py
+++ b/src/pipelines/epidemiology/de_covid_19_germany_gae.py
@@ -17,7 +17,6 @@ from typing import Dict, List
 from numpy import unique
 from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff
 
 
 class Covid19GermanyDataSource(DataSource):
@@ -44,8 +43,8 @@ class Covid19GermanyDataSource(DataSource):
                 records.append(
                     {
                         "subregion1_code": region_code,
-                        "confirmed": row["DE-%s_cases" % region_code],
-                        "deceased": row["DE-%s_deaths" % region_code],
+                        "total_confirmed": row["DE-%s_cases" % region_code],
+                        "total_deceased": row["DE-%s_deaths" % region_code],
                         **record,
                     }
                 )
@@ -55,6 +54,5 @@ class Covid19GermanyDataSource(DataSource):
         data = data.groupby(["date", "subregion1_code"]).last().reset_index()
 
         # Output the results
-        data = grouped_diff(data, ["subregion1_code", "date"])
         data["country_code"] = "DE"
         return data

--- a/src/pipelines/epidemiology/id_catchmeup.py
+++ b/src/pipelines/epidemiology/id_catchmeup.py
@@ -18,7 +18,7 @@ from pandas import DataFrame, concat, merge
 from lib.cast import safe_int_cast
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat
-from lib.utils import grouped_diff, pivot_table
+from lib.utils import pivot_table
 
 
 def _parse_date(date: str):
@@ -39,12 +39,11 @@ class CatchmeupDataSource(DataSource):
         df = pivot_table(df.transpose(), pivot_name="match_string")
         df["date"] = df["date"].apply(_parse_date)
         df = df.dropna(subset=["date"])
-        df = df.rename(columns={"value": "confirmed"})
-        df["confirmed"] = df["confirmed"].apply(safe_int_cast).astype("Int64")
+        df = df.rename(columns={"value": "total_confirmed"})
+        df["total_confirmed"] = df["total_confirmed"].apply(safe_int_cast).astype("Int64")
 
-        keep_columns = ["date", "match_string", "confirmed"]
+        df = df[["date", "match_string", "total_confirmed"]]
         df = df[df["match_string"] != "Total"]
         df = df[df["match_string"] != "Dalam proses investigasi"]
-        df = grouped_diff(df[keep_columns], ["match_string", "date"])
         df["country_code"] = "ID"
         return df

--- a/src/pipelines/epidemiology/mx_mexicovid19.py
+++ b/src/pipelines/epidemiology/mx_mexicovid19.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 from typing import Dict, List
-from pandas import DataFrame, concat, merge
+from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.utils import grouped_cumsum, pivot_table
+from lib.utils import pivot_table
 
 
 class Mexicovid19DataSource(DataSource):
@@ -25,7 +24,13 @@ class Mexicovid19DataSource(DataSource):
     ) -> DataFrame:
 
         data = None
-        ordered_columns = ["confirmed", "deceased", "tested", "hospitalized", "intensive_care"]
+        ordered_columns = [
+            "new_confirmed",
+            "new_deceased",
+            "new_tested",
+            "new_hospitalized",
+            "new_intensive_care",
+        ]
         for column_name, df in zip(ordered_columns, dataframes):
             df = df.rename(columns={"Fecha": "date"}).set_index("date")
             df = pivot_table(df, pivot_name="match_string").rename(columns={"value": column_name})
@@ -34,11 +39,8 @@ class Mexicovid19DataSource(DataSource):
             else:
                 data = data.merge(df, how="left")
 
-        # Compute the cumsum of data
-        data = grouped_cumsum(data, ["match_string", "date"])
-        data["country_code"] = "MX"
-
         # Country-level have a specific label
+        data["country_code"] = "MX"
         data.loc[data.match_string == "Nacional", "key"] = "MX"
 
         return data

--- a/src/pipelines/epidemiology/nl_authority.py
+++ b/src/pipelines/epidemiology/nl_authority.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame, concat
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff
 
 
 class NetherlandsDataSource(DataSource):
@@ -31,9 +30,9 @@ class NetherlandsDataSource(DataSource):
                 "Municipality_code": "subregion2_code",
                 "Municipality_name": "subregion2_name",
                 "Province": "subregion1_name",
-                "Total_reported": "confirmed",
-                "Hospital_admission": "hospitalized",
-                "Deceased": "deceased",
+                "Total_reported": "total_confirmed",
+                "Hospital_admission": "total_hospitalized",
+                "Deceased": "total_deceased",
             }
         )
 
@@ -52,10 +51,7 @@ class NetherlandsDataSource(DataSource):
         data = data.merge(aux["metadata"], on="subregion2_code")
 
         # We only need to keep key-date pair for identification
-        data = data[["date", "key", "confirmed", "deceased", "hospitalized"]]
-
-        # Compute the daily counts
-        data = grouped_diff(data, ["key", "date"])
+        data = data[["date", "key", "total_confirmed", "total_deceased", "total_hospitalized"]]
 
         # Group by level 2 region, and add the parts
         l2 = data.copy()

--- a/src/pipelines/epidemiology/pt_covid19.py
+++ b/src/pipelines/epidemiology/pt_covid19.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-from typing import Any, Dict, List
+from typing import Dict, List
 from numpy import unique
-from pandas import DataFrame, concat, merge
+from pandas import DataFrame, concat
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat
-from lib.utils import grouped_diff, pivot_table
+from lib.utils import pivot_table
 
 
 class PtCovid19L1DataSource(DataSource):
@@ -68,9 +67,14 @@ class PtCovid19L2DataSource(DataSource):
         data = subsets[0]
         for df in subsets[1:]:
             data = data.merge(df, how="outer")
-        data = data.rename(columns={"deaths": "deceased"})
+        data = data.rename(
+            columns={
+                "confirmed": "total_confirmed",
+                "deaths": "total_deceased",
+                "recovered": "total_recovered",
+            }
+        )
 
         data = data[data.match_string != "unconfirmed"]
-        data = grouped_diff(data, ["match_string", "date"])
         data["country_code"] = "PT"
         return data

--- a/src/pipelines/epidemiology/sd_humdata.py
+++ b/src/pipelines/epidemiology/sd_humdata.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.cast import safe_int_cast
 from lib.time import datetime_isoformat
-from lib.utils import grouped_cumsum
 
 
 class SudanHumdataDataSource(DataSource):

--- a/src/pipelines/epidemiology/se_authority.py
+++ b/src/pipelines/epidemiology/se_authority.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from typing import Dict, List
-from pandas import DataFrame, concat, merge
+from pandas import DataFrame
 from lib.io import read_file
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff, grouped_cumsum, pivot_table
+from lib.utils import pivot_table
 
 
 class SwedenDataSource(DataSource):
@@ -35,5 +35,4 @@ class SwedenDataSource(DataSource):
         data = pivot_table(data, pivot_name="match_string")
 
         data["country_code"] = "SE"
-        data = data.rename(columns={"value": "confirmed"})
-        return grouped_cumsum(data, ["country_code", "match_string", "date"])
+        return data.rename(columns={"value": "new_confirmed"})

--- a/src/pipelines/epidemiology/us_covidtracking.py
+++ b/src/pipelines/epidemiology/us_covidtracking.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat
-from lib.utils import grouped_diff
 
 
 class CovidTrackingDataSource(DataSource):

--- a/src/pipelines/epidemiology/us_nyt_covid.py
+++ b/src/pipelines/epidemiology/us_nyt_covid.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff
 
 
 class NytCovidL2DataSource(DataSource):
@@ -29,8 +27,8 @@ class NytCovidL2DataSource(DataSource):
             columns={
                 "date": "date",
                 "state": "subregion1_name",
-                "cases": "confirmed",
-                "deaths": "deceased",
+                "cases": "total_confirmed",
+                "deaths": "total_deceased",
             }
         )
 
@@ -46,10 +44,6 @@ class NytCovidL2DataSource(DataSource):
 
         # Manually build the key rather than doing automated merge for performance reasons
         data["key"] = "US_" + data["subregion1_code"]
-
-        # Now that we have the key, we don't need any other non-value columns
-        data = data[["date", "key", "confirmed", "deceased"]]
-        data = grouped_diff(data, ["key", "date"])
         return data
 
 
@@ -66,8 +60,8 @@ class NytCovidL3DataSource(DataSource):
                     "date": "date",
                     "state": "subregion1_name",
                     "fips": "subregion2_code",
-                    "cases": "confirmed",
-                    "deaths": "deceased",
+                    "cases": "total_confirmed",
+                    "deaths": "total_deceased",
                 }
             )
             .drop(columns=["county"])
@@ -90,7 +84,4 @@ class NytCovidL3DataSource(DataSource):
         # Manually build the key rather than doing automated merge for performance reasons
         data["key"] = "US_" + data["subregion1_code"] + "_" + data["subregion2_code"]
 
-        # Now that we have the key, we don't need any other non-value columns
-        data = data[["date", "key", "confirmed", "deceased"]]
-        data = grouped_diff(data, ["key", "date"])
         return data

--- a/src/pipelines/epidemiology/ve_humdata.py
+++ b/src/pipelines/epidemiology/ve_humdata.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
 from lib.cast import safe_int_cast
-from lib.utils import grouped_diff, pivot_table
+from lib.utils import pivot_table
 
 
 class VenezuelaHumDataSource(DataSource):
@@ -24,14 +24,11 @@ class VenezuelaHumDataSource(DataSource):
         self, dataframes: List[DataFrame], aux: Dict[str, DataFrame], **parse_opts
     ) -> DataFrame:
         data = pivot_table(dataframes[0].set_index("date"), pivot_name="match_string").rename(
-            columns={"value": "confirmed"}
+            columns={"value": "total_confirmed"}
         )
 
         # Remove cities from output
         data = data[~data.match_string.isin(["La Guaira", "Los Roques"])]
-
-        # Compute daily differences
-        data = grouped_diff(data, ["match_string", "date"])
 
         # Add country code and return
         data["country_code"] = "VE"

--- a/src/pipelines/epidemiology/xx_covid19_eu_data.py
+++ b/src/pipelines/epidemiology/xx_covid19_eu_data.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff
 
 
 class Covid19EuDataSource(DataSource):
@@ -30,12 +29,12 @@ class Covid19EuDataSource(DataSource):
                 "country": "country_code",
                 "nuts_2": "match_string",
                 "nuts_3": "match_string",
-                "cases": "confirmed",
-                "deaths": "deceased",
-                "tests": "tested",
-                "recovered": "recovered",
-                "hospitalized": "hospitalized",
-                "intensive_care": "icu",
+                "cases": "total_confirmed",
+                "deaths": "total_deceased",
+                "tests": "total_tested",
+                "recovered": "total_recovered",
+                "hospitalized": "total_hospitalized",
+                "icu": "total_intensive_care",
             }
         )
         data["date"] = data["date"].apply(lambda x: datetime.fromisoformat(x))
@@ -52,10 +51,4 @@ class Covid19EuDataSource(DataSource):
         data = data[[col for col in data.columns if not "/" in col]]
 
         # Some tables have repeated data
-        data = data.groupby(["country_code", "match_string", "date"]).last().reset_index()
-
-        return grouped_diff(
-            data,
-            ["country_code", "match_string", "date"],
-            skip=["tests", "recovered", "hospitalized", "icu"],
-        )
+        return data.groupby(["country_code", "match_string", "date"]).last().reset_index()

--- a/src/pipelines/epidemiology/xx_dxy.py
+++ b/src/pipelines/epidemiology/xx_dxy.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from typing import Dict, List
-from pandas import DataFrame, concat, merge
+from pandas import DataFrame
 from lib.pipeline import DataSource
 from lib.time import timezone_adjust
-from lib.utils import grouped_diff
 
 
 class DXYDataSource(DataSource):
@@ -33,9 +32,9 @@ class DXYDataSource(DataSource):
             columns={
                 "countryEnglishName": "country_name",
                 "provinceEnglishName": "match_string",
-                "province_confirmedCount": "confirmed",
-                "province_deadCount": "deceased",
-                "province_curedCount": "recovered",
+                "province_confirmedCount": "total_confirmed",
+                "province_deadCount": "total_deceased",
+                "province_curedCount": "total_recovered",
             }
         )
 
@@ -54,8 +53,8 @@ class DXYDataSource(DataSource):
             "date",
             "country_name",
             "match_string",
-            "confirmed",
-            "deceased",
-            "recovered",
+            "total_confirmed",
+            "total_deceased",
+            "total_recovered",
         ]
-        return grouped_diff(data[keep_columns], ["country_name", "match_string", "date"])
+        return data[keep_columns]

--- a/src/pipelines/epidemiology/xx_ecdc.py
+++ b/src/pipelines/epidemiology/xx_ecdc.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, isnull
+from typing import Dict, List
+from pandas import DataFrame
 from lib.cast import safe_int_cast
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat, date_offset
-from lib.utils import get_or_default, grouped_cumsum
+from lib.utils import get_or_default
 
 
 class ECDCDataSource(DataSource):
@@ -63,12 +63,14 @@ class ECDCDataSource(DataSource):
         # Remove bogus entries (cruiseships, etc.)
         data = data[~data["geoId"].apply(lambda code: len(code) > 2)]
 
-        data = data.rename(columns={"geoId": "key", "cases": "confirmed", "deaths": "deceased"})
+        data = data.rename(
+            columns={"geoId": "key", "cases": "new_confirmed", "deaths": "new_deceased"}
+        )
 
         # Adjust the date of the records to match local reporting
         data = self._adjust_date(data, metadata)
 
         # Keep only the columns we can process
-        data = data[["date", "key", "confirmed", "deceased"]]
+        data = data[["date", "key", "new_confirmed", "new_deceased"]]
 
-        return grouped_cumsum(data, ["key", "date"])
+        return data

--- a/src/pipelines/hospitalizations/gb_authority.py
+++ b/src/pipelines/hospitalizations/gb_authority.py
@@ -17,7 +17,7 @@ from pandas import DataFrame
 from lib.cast import safe_float_cast
 from lib.io import read_file
 from lib.pipeline import DataSource
-from lib.utils import grouped_diff, grouped_cumsum, pivot_table
+from lib.utils import pivot_table
 
 
 class ScotlandDataSource(DataSource):
@@ -34,9 +34,6 @@ class ScotlandDataSource(DataSource):
         # Get date in ISO format
         data.date = data.date.apply(lambda x: x.date().isoformat())
 
-        # Compute cumsum of values
-        data = grouped_cumsum(data, ["match_string", "date"])
-
         # Add metadata
         data["key"] = None
         data["country_code"] = "GB"
@@ -48,10 +45,10 @@ class ScotlandDataSource(DataSource):
 
     def parse(self, sources: List[str], aux: Dict[str, DataFrame], **parse_opts) -> DataFrame:
         hospitalized = ScotlandDataSource._parse(
-            sources[0], sheet_name="Table 3a - Hospital Confirmed", value_name="hospitalized"
+            sources[0], sheet_name="Table 3a - Hospital Confirmed", value_name="new_hospitalized"
         )
         intensive_care = ScotlandDataSource._parse(
-            sources[0], sheet_name="Table 2 - ICU patients", value_name="intensive_care"
+            sources[0], sheet_name="Table 2 - ICU patients", value_name="new_intensive_care"
         )
 
         return hospitalized.merge(intensive_care, how="outer")

--- a/src/pipelines/hospitalizations/se_authority.py
+++ b/src/pipelines/hospitalizations/se_authority.py
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
-from pandas import DataFrame, concat, merge
+from typing import Dict, List
+from pandas import DataFrame
 from lib.io import read_file
 from lib.pipeline import DataSource
 from lib.time import datetime_isoformat
-from lib.utils import grouped_diff, grouped_cumsum, pivot_table
+from lib.utils import pivot_table
 
 
 class SwedenDataSource(DataSource):
     def parse(self, sources: List[str], aux: Dict[str, DataFrame], **parse_opts) -> DataFrame:
 
         data = read_file(sources[0], sheet_name="Antal intensivvårdade per dag").rename(
-            columns={"Datum_vårdstart": "date", "Antal_intensivvårdade": "intensive_care"}
+            columns={"Datum_vårdstart": "date", "Antal_intensivvårdade": "new_intensive_care"}
         )
 
         # Get date in ISO format
         data["key"] = "SE"
         data.date = data.date.apply(lambda x: datetime_isoformat(x, "%m/%d/%Y"))
-        return grouped_cumsum(data, ["key", "date"])
+        return data


### PR DESCRIPTION
This PR removes all references to `grouped_diff` and `grouped_cumsum` within the data source parsers, since it's all done automatically as part of the pipeline processing now.