### PR TITLE
Replace ROOT with SRC

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,21 +22,21 @@ from functools import partial
 from argparse import ArgumentParser
 from typing import Any, Callable, Dict, List
 
-from lib.utils import ROOT
+from lib.utils import SRC
 
 
 def parse_command(cmd: str) -> List[str]:
     if cmd == "curl":
-        return ["python3", str(ROOT / "src" / "cache" / "commands" / "curl_fetch.py")]
+        return ["python3", str(SRC / "cache" / "commands" / "curl_fetch.py")]
     if cmd == "static_fetch":
-        return ["python3", str(ROOT / "src" / "cache" / "commands" / "static_fetch.py")]
+        return ["python3", str(SRC / "cache" / "commands" / "static_fetch.py")]
     if cmd == "dynamic_fetch":
-        return ["node", str(ROOT / "src" / "cache" / "commands" / "dynamic_fetch.js")]
+        return ["node", str(SRC / "cache" / "commands" / "dynamic_fetch.js")]
     if cmd.startswith("dynamic_custom/"):
         script_name = cmd.split("/")[-1]
         script_extension = script_name.split(".")[-1]
         assert script_extension == "js", "Dynamic script must be a NodeJS script"
-        return ["node", str(ROOT / "src" / "cache" / "commands" / "dynamic_custom" / script_name)]
+        return ["node", str(SRC / "cache" / "commands" / "dynamic_custom" / script_name)]
     raise ValueError(f"Unknown command {cmd}")
 
 
@@ -92,13 +93,13 @@ def error_handler(error_message: str):
 # Create the output folder for the nearest hour in UTC time
 now = datetime.utcnow()
 output_name = now.strftime("%Y-%m-%d-%H")
-output_path = ROOT / "output" / "cache"
+output_path = SRC / ".." / "output" / "cache"
 snapshot_path = output_path / output_name
 snapshot_path.mkdir(parents=True, exist_ok=True)
 
 # Iterate over each source and process it
 map_func = partial(process_source, snapshot_path, error_handler)
-for source in json.load((ROOT / "src" / "cache" / "config.json").open("r")):
+for source in json.load((SRC / "cache" / "config.json").open("r")):
     map_func(source)
 
 # Build a "sitemap" of the cache output folder

--- a/src/lib/concurrent.py
+++ b/src/lib/concurrent.py
@@ -15,7 +15,7 @@
 from os import getenv
 from typing import Any, Callable, Iterable
 from tqdm.contrib import concurrent
-from multiprocess.pool import Pool, ThreadPool
+from multiprocessing.pool import Pool, ThreadPool
 from .io import GLOBAL_DISABLE_PROGRESS
 
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -21,7 +21,7 @@ from pandas import DataFrame, Series, concat, isna, merge
 from pandas.api.types import is_numeric_dtype
 from .io import fuzzy_text, pbar, tqdm
 
-ROOT = Path(os.path.dirname(__file__)) / ".." / ".."
+SRC = Path(os.path.dirname(__file__)) / ".."
 URL_OUTPUTS_PROD = "https://storage.googleapis.com/covid19-open-data/v2"
 CACHE_URL = "https://raw.githubusercontent.com/open-covid-19/data/cache"
 

--- a/src/pipelines/_template/config.yaml
+++ b/src/pipelines/_template/config.yaml
@@ -24,9 +24,9 @@ schema:
 
 # Auxiliary datasets passed to each pipeline as argument to `parse`
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 # Defines the pipelines to be run in order to produce the combined, full output
 sources:

--- a/src/pipelines/by_age/config.yaml
+++ b/src/pipelines/by_age/config.yaml
@@ -199,9 +199,9 @@ schema:
   age_bin_09: str
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
 

--- a/src/pipelines/by_sex/config.yaml
+++ b/src/pipelines/by_sex/config.yaml
@@ -53,9 +53,9 @@ schema:
   current_ventilator_female: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
 

--- a/src/pipelines/demographics/config.yaml
+++ b/src/pipelines/demographics/config.yaml
@@ -37,11 +37,11 @@ schema:
   population_age_90_99: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  worldpop: ./src/data/worldpop_stratified.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
-  worldbank_indicators: ./src/data/worldbank_indicators.csv
+  metadata: ./data/metadata.csv
+  worldpop: ./data/worldpop_stratified.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
+  worldbank_indicators: ./data/worldbank_indicators.csv
 
 sources:
 

--- a/src/pipelines/economy/config.yaml
+++ b/src/pipelines/economy/config.yaml
@@ -21,10 +21,10 @@ schema:
   human_capital_index: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
-  worldbank_indicators: ./src/data/worldbank_indicators.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
+  worldbank_indicators: ./data/worldbank_indicators.csv
 
 sources:
   - name: pipelines._common.wikidata.WikidataDataSource

--- a/src/pipelines/epidemiology/config.yaml
+++ b/src/pipelines/epidemiology/config.yaml
@@ -27,9 +27,9 @@ schema:
   total_tested: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
 

--- a/src/pipelines/epidemiology/config.yaml
+++ b/src/pipelines/epidemiology/config.yaml
@@ -653,6 +653,9 @@ sources:
       - url: "https://dshs.texas.gov/coronavirus/TexasCOVID19CaseCountData.xlsx"
     test:
       metadata_query: "key == 'US_TX'"
+      # Skip Texas because the data source is very flaky and keeps changing schema
+      # TODO: fix this data source and make it more resilient
+      skip: true
 
   # Data sources for VE level 2
   - name: pipelines.epidemiology.ve_humdata.VenezuelaHumDataSource

--- a/src/pipelines/epidemiology/us_dc_authority.py
+++ b/src/pipelines/epidemiology/us_dc_authority.py
@@ -21,6 +21,7 @@ from lib.cast import safe_float_cast
 from lib.io import read_file
 from lib.net import download_snapshot, download
 from lib.pipeline import DataSource
+from lib.time import datetime_isoformat
 from lib.utils import pivot_table_date_columns, table_rename
 
 
@@ -106,7 +107,7 @@ class DistrictColumbiaDataSource(DataSource):
         data = _sheet_processors[parse_opts.get("sheet_name")](data)
 
         # Fix up the date format
-        data.date = data.date.apply(lambda x: x.date().isoformat())
+        data["date"] = data["date"].apply(lambda x: datetime_isoformat(x, "%Y-%m-%d %H:%M:%S"))
 
         # Add a key to all the records (state-level only)
         data["key"] = "US_DC"

--- a/src/pipelines/geography/config.yaml
+++ b/src/pipelines/geography/config.yaml
@@ -25,10 +25,10 @@ schema:
   urban_area: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
-  worldbank_indicators: ./src/data/worldbank_indicators.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
+  worldbank_indicators: ./data/worldbank_indicators.csv
 
 sources:
 

--- a/src/pipelines/health/config.yaml
+++ b/src/pipelines/health/config.yaml
@@ -31,10 +31,10 @@ schema:
   out_of_pocket_health_expenditure: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
-  worldbank_indicators: ./src/data/worldbank_indicators.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
+  worldbank_indicators: ./data/worldbank_indicators.csv
 
 sources:
 

--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -298,6 +298,9 @@ sources:
       - url: "https://dshs.texas.gov/coronavirus/TexasCOVID19CaseCountData.xlsx"
     test:
       metadata_query: "key == 'US_TX'"
+      # Skip Texas because the data source is very flaky and keeps changing schema
+      # TODO: fix this data source and make it more resilient
+      skip: true
 
   # Data sources for ZA levels 1 + 2
   - name: pipelines.epidemiology.za_dsfsi.Covid19ZaCumulativeDataSource

--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -28,9 +28,9 @@ schema:
   current_ventilator: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
 

--- a/src/pipelines/index/config.yaml
+++ b/src/pipelines/index/config.yaml
@@ -29,9 +29,9 @@ schema:
   aggregation_level: int
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
   - name: pipelines.index.index.IndexDataSource

--- a/src/pipelines/mobility/config.yaml
+++ b/src/pipelines/mobility/config.yaml
@@ -28,9 +28,9 @@ schema:
   mobility_residential: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
 

--- a/src/pipelines/oxford_government_response/config.yaml
+++ b/src/pipelines/oxford_government_response/config.yaml
@@ -37,9 +37,9 @@ schema:
   stringency_index: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
   - name: pipelines.oxford_government_response.oxford_government_response.OxfordGovernmentResponseDataSource

--- a/src/pipelines/weather/config.yaml
+++ b/src/pipelines/weather/config.yaml
@@ -26,9 +26,9 @@ schema:
   snowfall: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  knowledge_graph: ./src/data/knowledge_graph.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
   # Data is fetched dynamically, so no URL can be declared here

--- a/src/pipelines/worldbank/config.yaml
+++ b/src/pipelines/worldbank/config.yaml
@@ -1422,9 +1422,9 @@ schema:
   VC.PKP.TOTL.UN: float
 
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  country_codes: ./src/data/country_codes.csv
-  worldbank_indicators: ./src/data/worldbank_indicators.csv
+  metadata: ./data/metadata.csv
+  country_codes: ./data/country_codes.csv
+  worldbank_indicators: ./data/worldbank_indicators.csv
 
 sources:
 

--- a/src/pipelines/worldpop/config.yaml
+++ b/src/pipelines/worldpop/config.yaml
@@ -53,8 +53,8 @@ schema:
   m_75: int
   m_80: int
 auxiliary:
-  metadata: ./src/data/metadata.csv
-  worldpop: ./src/data/worldpop_stratified.csv
+  metadata: ./data/metadata.csv
+  worldpop: ./data/worldpop_stratified.csv
 
 sources:
 

--- a/src/publish.py
+++ b/src/publish.py
@@ -27,7 +27,7 @@ from pandas import DataFrame, date_range
 
 from lib.concurrent import thread_map
 from lib.io import read_file, export_csv, pbar
-from lib.utils import ROOT, drop_na_records
+from lib.utils import SRC, drop_na_records
 
 
 def subset_last_days(output_folder: Path, days: int) -> None:
@@ -178,11 +178,12 @@ def main(output_folder: Path, tables_folder: Path, show_progress: bool = True) -
 if __name__ == "__main__":
 
     # Process command-line arguments
+    output_root = SRC / ".." / "output"
     argparser = ArgumentParser()
     argparser.add_argument("--profile", action="store_true")
     argparser.add_argument("--no-progress", action="store_true")
-    argparser.add_argument("--tables-folder", type=str, default=str(ROOT / "output" / "tables"))
-    argparser.add_argument("--output-folder", type=str, default=str(ROOT / "output" / "public"))
+    argparser.add_argument("--tables-folder", type=str, default=str(output_root / "tables"))
+    argparser.add_argument("--output-folder", type=str, default=str(output_root / "public"))
     args = argparser.parse_args()
 
     if args.profile:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.8.2
-multiprocess==0.70.9
 pandas==1.0.3
 PyYAML==5.3.1
 requests==2.23
@@ -8,3 +7,4 @@ Scrapy==2.0.0
 tqdm==4.43.0
 Unidecode==1.1.1
 xlrd==1.2.0
+google-cloud-storage==1.29.0

--- a/src/scripts/backcompat.py
+++ b/src/scripts/backcompat.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from lib.forecast import main as build_forecast
 from lib.io import read_file, export_csv, pbar
 from lib.net import download
-from lib.utils import ROOT, URL_OUTPUTS_PROD, drop_na_records
+from lib.utils import SRC, URL_OUTPUTS_PROD, drop_na_records
 
 
 def snake_to_camel_case(txt: str) -> str:
@@ -38,7 +38,7 @@ def snake_to_camel_case(txt: str) -> str:
 if __name__ == "__main__":
 
     # Create the folder which will be published
-    public_folder = ROOT / "output" / "public"
+    public_folder = SRC / ".." / "output" / "public"
     public_folder.mkdir(exist_ok=True, parents=True)
 
     # Create the v1 data.csv file

--- a/src/scripts/list_pipelines.py
+++ b/src/scripts/list_pipelines.py
@@ -28,12 +28,12 @@ sys.path.append(path)
 
 from pandas import DataFrame
 from lib.pipeline import DataPipeline
-from lib.utils import ROOT
+from lib.utils import SRC
 from typing import List, Iterator, Dict
 
 
 def get_pipeline_names() -> Iterator[str]:
-    for item in (ROOT / "src" / "pipelines").iterdir():
+    for item in (SRC / "pipelines").iterdir():
         if not item.name.startswith("_") and not item.is_file():
             yield item.name
 
@@ -65,7 +65,7 @@ def get_source_configs(pipeline_names: List[str]) -> Iterator[Dict]:
 def get_cache_configs() -> Iterator[Dict]:
     """Generate a list of configurations for cached data sources."""
 
-    config_json = ROOT / "src" / "cache" / "config.json"
+    config_json = SRC / "cache" / "config.json"
     with open(config_json, "r") as fd:
         cache_pipelines_config = json.load(fd)
         for pipeline_config in cache_pipelines_config:
@@ -79,5 +79,5 @@ if __name__ == "__main__":
     print(source_configs_df)
     print(cache_configs_df)
 
-    source_configs_df.to_csv(ROOT / "tmp" / "source_configs.csv")
-    cache_configs_df.to_csv(ROOT / "tmp" / "cache_configs.csv")
+    source_configs_df.to_csv(SRC / ".." / "tmp" / "source_configs.csv")
+    cache_configs_df.to_csv(SRC / ".." / "tmp" / "cache_configs.csv")

--- a/src/scripts/nuts_breakdown.py
+++ b/src/scripts/nuts_breakdown.py
@@ -23,7 +23,7 @@ import datacommons as dc
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from lib.io import read_file
-from lib.utils import ROOT
+from lib.utils import SRC
 
 
 # Parse arguments from the command line
@@ -34,11 +34,11 @@ argparser.add_argument("--dc-api-key", type=str, default=os.environ["DATACOMMONS
 args = argparser.parse_args()
 
 # Get the country name
-aux = read_file(ROOT / "src" / "data" / "metadata.csv").set_index("key")
+aux = read_file(SRC / "data" / "metadata.csv").set_index("key")
 country_name = aux.loc[args.country_code, "country_name"]
 
 # Convert 2-letter to 3-letter country code
-iso_codes = read_file(ROOT / "src" / "data" / "country_codes.csv").set_index("key")
+iso_codes = read_file(SRC / "data" / "country_codes.csv").set_index("key")
 country_code_alpha_3 = iso_codes.loc[args.country_code, "3166-1-alpha-3"]
 
 dc.set_api_key(args.dc_api_key)

--- a/src/test/test_source_run.py
+++ b/src/test/test_source_run.py
@@ -22,7 +22,7 @@ from tempfile import TemporaryDirectory
 import requests
 from lib.io import pbar
 from lib.pipeline import DataPipeline
-from lib.utils import ROOT, CACHE_URL
+from lib.utils import SRC, CACHE_URL
 from .profiled_test_case import ProfiledTestCase
 
 
@@ -31,7 +31,7 @@ METADATA_SAMPLE_SIZE = 24
 
 
 def _get_all_pipelines() -> Iterable[str]:
-    for item in (ROOT / "src" / "pipelines").iterdir():
+    for item in (SRC / "pipelines").iterdir():
         if not item.name.startswith("_") and not item.is_file():
             yield item.name
 

--- a/src/update.py
+++ b/src/update.py
@@ -22,7 +22,7 @@ from typing import List
 
 from lib.io import export_csv, display_progress
 from lib.pipeline import DataPipeline
-from lib.utils import ROOT
+from lib.utils import SRC
 
 
 def main(
@@ -64,7 +64,7 @@ def main(
 
         # A pipeline chain is any subfolder not starting with "_" in the pipelines folder
         all_pipeline_names = []
-        for item in (ROOT / "src" / "pipelines").iterdir():
+        for item in (SRC / "pipelines").iterdir():
             if not item.name.startswith("_") and not item.is_file():
                 all_pipeline_names.append(item.name)
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     argparser.add_argument("--profile", action="store_true")
     argparser.add_argument("--no-progress", action="store_true")
     argparser.add_argument("--process-count", type=int, default=cpu_count())
-    argparser.add_argument("--output-folder", type=str, default=str(ROOT / "output"))
+    argparser.add_argument("--output-folder", type=str, default=str(SRC / ".." / "output"))
     args = argparser.parse_args()
 
     if args.profile:


### PR DESCRIPTION
This change allows for the deployment of only the `src` folder without having to clone the whole repo. Useful for things like appengine.