### PR TITLE
Fix missing entry in iso_3166_2_codes

### DIFF
--- a/src/data/iso_3166_2_codes.csv
+++ b/src/data/iso_3166_2_codes.csv
@@ -1725,7 +1725,7 @@ GD_06,Q1476309,GD,06,Saint Patrick Parish
 GD_10,Q3044818,GD,10,Carriacou and Petite Martinique
 GE_29,Q175786,GE,29,Khelvachauri Municipality
 GE_50,Q2490876,GE,50,Senaki Municipality
-GE_25,Q1518087,Kaspi Municipality
+GE_25,Q1518087,GE,25,Kaspi Municipality
 GE_AB,Q2914461,GE,AB,Autonomous Republic of Abkhazia
 GE_AJ,Q45693,GE,AJ,Adjara
 GE_GU,Q19038,GE,GU,Guria


### PR DESCRIPTION
The entry for GE_25 was missing a region and subregion1_code.